### PR TITLE
Fix: Update spots thunk to handle correct response format

### DIFF
--- a/frontend/src/store/spots.js
+++ b/frontend/src/store/spots.js
@@ -11,7 +11,7 @@ export const fetchSpots = createAsyncThunk(
             throw new Error(error.message || 'Failed to fetch spots');
         }
         const data = await response.json();
-        return data.Spots || data;
+        return data.Spots;
     }
 );
 export const fetchSpotDetails = createAsyncThunk(


### PR DESCRIPTION
This PR fixes the spots not showing on the landing page by correctly handling the API response format from /api/spots endpoint.